### PR TITLE
Added vim normal mode scrolling support

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,5 @@
     "sass": "^1.30.0",
     "tslib": "^2.0.3",
     "typescript": "^4.1.3"
-  },
-  "dependencies": {}
+  }
 }

--- a/typewriter-scrolling.js
+++ b/typewriter-scrolling.js
@@ -1,9 +1,6 @@
 // all credit to azu: https://github.com/azu/codemirror-typewriter-scrolling/blob/b0ac076d72c9445c96182de87d974de2e8cc56e2/typewriter-scrolling.js
 "use strict";
 CodeMirror.commands.scrollSelectionToCenter = function (cm) {
-    if (cm.getOption("disableInput")) {
-        return CodeMirror.Pass;
-    }
     var cursor = cm.getCursor('head');
     var charCoords = cm.charCoords(cursor, "local");
     var top = charCoords.top;
@@ -17,38 +14,24 @@ CodeMirror.defineOption("typewriterScrolling", false, function (cm, val, old) {
         const linesEl = cm.getScrollerElement().querySelector('.CodeMirror-lines');
         linesEl.style.paddingTop = null;
         linesEl.style.paddingBottom = null;
-        cm.off("changes", onChanges);
         cm.off("cursorActivity", onCursorActivity);
-        cm.off("keyHandled", onKeyHandled);
         cm.off("refresh", onRefresh);
     }
     if (val) {
         onRefresh(cm);
-        cm.on("changes", onChanges);
         cm.on("cursorActivity", onCursorActivity);
-        cm.on("keyHandled", onKeyHandled);
         cm.on("refresh", onRefresh);
     }
 });
-function onChanges(cm, changes) {
-    if (cm.getSelection().length !== 0) {
-        return;
-    }
-    for (var i = 0, len = changes.length; i < len; i++) {
-        var each = changes[i];
-        if (each.origin === '+input' || each.origin === '+delete') {
-            cm.execCommand("scrollSelectionToCenter");
-            return;
-        }
-    }
-}
 function onCursorActivity(cm) {
     const linesEl = cm.getScrollerElement().querySelector('.CodeMirror-lines');
     if (cm.getSelection().length !== 0) {
-        linesEl.classList.add("selecting")
+        linesEl.classList.add("selecting");
     }
     else {
-        linesEl.classList.remove("selecting")
+        linesEl.classList.remove("selecting");
+        cm.execCommand("scrollSelectionToCenter");
+        console.log(cm.getOption('mode'));
     }
 }
 function onRefresh(cm) {
@@ -57,12 +40,6 @@ function onRefresh(cm) {
     linesEl.style.paddingTop = `${halfWindowHeight}px`;
     linesEl.style.paddingBottom = `${halfWindowHeight}px`; // Thanks @walulula!
     if (cm.getSelection().length === 0) {
-        cm.execCommand("scrollSelectionToCenter");
-    }
-}
-function onKeyHandled(cm, name, event) {
-    console.log(name);
-    if (name === "Up" || name === "Down" || name === "Left" || name === "Right") {
         cm.execCommand("scrollSelectionToCenter");
     }
 }


### PR DESCRIPTION
Changed `typewriter-scrolling.js` logic to support scrolling in vim normal mode in the editor by:
- Detecting cursor movements instead of keypresses and inputs / deletions
- Allowing scrolling while input is disabled (normal mode)

This is a little bit jarring if you use the mouse to change selection though since that also counts as a cursor movement. Perhaps some sort of solution would involve disabling scrolling while the mouse is clicked but codemirror doesn't seem to support a mouseup event.