### PR TITLE
Disable top padding for codemirror view

### DIFF
--- a/extension.ts
+++ b/extension.ts
@@ -14,7 +14,6 @@ const resetTypewriterScrollPaddingPlugin = ViewPlugin.fromClass(class {
 
   update(update: ViewUpdate) {
     if (this.view.contentDOM.style.paddingTop) {
-      this.view.contentDOM.style.paddingTop = ""
       this.view.contentDOM.style.paddingBottom = (update.view.dom.clientHeight / 2) + "px";
     }
   }
@@ -29,7 +28,6 @@ const typewriterScrollPaddingPlugin = ViewPlugin.fromClass(class {
     const offset = (update.view.dom.clientHeight * update.view.state.facet(typewriterOffset)) - (update.view.defaultLineHeight / 2)
     this.topPadding = offset + "px"
     if (this.topPadding != this.view.contentDOM.style.paddingTop) {
-      this.view.contentDOM.style.paddingTop = this.topPadding
       this.view.contentDOM.style.paddingBottom = (update.view.dom.clientHeight - offset) + "px";
     }
   }


### PR DESCRIPTION
This addresses https://github.com/deathau/cm-typewriter-scroll-obsidian/issues/35

This is a very simple change.

I guess depending on the maintainer's preferences, whether padding is enabled or not can be determined based on the obsidian config instead.
So the padding would be disabled if the file title is shown or enabled otherwise.
Padding the title can be also implemented as an alternative.